### PR TITLE
jsonrpc autoconnect, indexes client recovery, docker volumes, bugfixes

### DIFF
--- a/chainstore/chainstore.go
+++ b/chainstore/chainstore.go
@@ -102,9 +102,10 @@ func (s *Store) LoadAndPrune(ctx context.Context, currHead types.TipSetKey, valu
 }
 
 func (s *Store) load(tsk types.TipSetKey, v interface{}) error {
-	buf, err := s.ds.Get(toKeyData(tsk))
+	key := toKeyData(tsk)
+	buf, err := s.ds.Get(key)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting key %s: %s", key, err)
 	}
 	if err := cbor.DecodeInto(buf, v); err != nil {
 		return err

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,5 +1,8 @@
 version: '3.7'
 
+volumes:
+  textile-fc-data:
+
 services:
   textile-fc:
     network_mode: host
@@ -10,7 +13,10 @@ services:
       - TEXTILE_LOTUS_TOKEN=${TEXTILE_LOTUS_TOKEN}
     ports:
       - 8888:8888
+      - 6060:6060
     restart: always
+    volumes:
+      - textile-fc-data:/root/.texfc
     
   prometheus:
     network_mode: host

--- a/docker/grafana/provisioning/dashboards/TextileFC.json
+++ b/docker/grafana/provisioning/dashboards/TextileFC.json
@@ -523,7 +523,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "On-Chain Progress",
+      "title": "On-Chain Refresh",
       "type": "gauge"
     },
     {
@@ -597,7 +597,7 @@
       "thresholds": "",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Height",
+      "title": "Index Height",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -684,7 +684,7 @@
       "thresholds": "",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Avg Full-Refresh Duration",
+      "title": "Full-Refresh Duration",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -768,7 +768,7 @@
       "thresholds": "",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Avg Delta-Refresh Duration",
+      "title": "Delta-Refresh Duration",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -828,7 +828,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Meta Progress",
+      "title": "Meta Refresh",
       "type": "gauge"
     },
     {
@@ -884,7 +884,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Current #Miners on-chain",
+      "title": "#Miners Ping Reply",
       "type": "bargauge"
     },
     {
@@ -948,7 +948,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Full refresh progress",
+      "title": "Full Refresh",
       "type": "gauge"
     },
     {
@@ -1022,7 +1022,7 @@
       "thresholds": "",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Last Refresh Duration",
+      "title": "Refresh Duration",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1032,7 +1032,7 @@
           "value": "null"
         }
       ],
-      "valueName": "current"
+      "valueName": "avg"
     },
     {
       "cacheTimeout": null,
@@ -1082,7 +1082,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Last Query-Ask Response",
+      "title": "Last Query-Ask Reply",
       "type": "bargauge"
     },
     {
@@ -1156,8 +1156,92 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Refresh Progress",
+      "title": "Refresh",
       "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 2,
+        "y": 15
+      },
+      "id": 37,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "pluginVersion": "6.5.3",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "textilefc_indexslashing_updated_height",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Index Height",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
     }
   ],
   "refresh": "5s",

--- a/exe/server/Dockerfile
+++ b/exe/server/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o main cmd/server/main.go
 
 FROM alpine
+COPY --from=builder /app/api/server/ip2location-ip4.bin /app/ip2location-ip4.bin
 COPY --from=builder /app/main /app/main
-COPY --from=builder /app/api/server/ip2location-ip4.bin /app
 WORKDIR /app 
 ENTRYPOINT ["./main"]

--- a/exe/server/main.go
+++ b/exe/server/main.go
@@ -11,6 +11,7 @@ import (
 	logging "github.com/ipfs/go-log"
 	"github.com/textileio/filecoin/api/server"
 	"github.com/textileio/filecoin/tests"
+	_ "net/http/pprof"
 )
 
 var (
@@ -25,7 +26,9 @@ func main() {
 	logging.SetLogLevel("rpc", "error")
 	logging.SetLogLevel("dht", "error")
 	logging.SetLogLevel("swarm2", "error")
+
 	instrumentationSetup()
+	pprofSetup()
 
 	// ToDo: Flags for configuration
 
@@ -71,5 +74,11 @@ func instrumentationSetup() {
 		if err := http.ListenAndServe(":8888", mux); err != nil {
 			log.Fatalf("Failed to run Prometheus scrape endpoint: %v", err)
 		}
+	}()
+}
+
+func pprofSetup() {
+	go func() {
+		log.Error(http.ListenAndServe("localhost:6060", nil))
 	}()
 }

--- a/index/miner/meta.go
+++ b/index/miner/meta.go
@@ -49,6 +49,7 @@ func (mi *MinerIndex) metaWorker() {
 			newIndex, err := updateMetaIndex(mi.ctx, mi.api, mi.h, mi.lr, addrs)
 			if err != nil {
 				log.Errorf("error when updating meta index: %s", err)
+				break
 			}
 			if err := mi.persistMetaIndex(newIndex); err != nil {
 				log.Errorf("error when persisting meta index: %s", err)

--- a/index/miner/meta.go
+++ b/index/miner/meta.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/textileio/filecoin/fchost"
 	"github.com/textileio/filecoin/iplocation"
@@ -15,7 +14,7 @@ import (
 )
 
 const (
-	metadataRefreshInterval = time.Second * 30
+	metadataRefreshInterval = time.Second * 45
 	pingTimeout             = time.Second * 3
 	pingRateLim             = 100
 )
@@ -149,35 +148,5 @@ func (mi *MinerIndex) persistMetaIndex(index MetaIndex) error {
 	if err := mi.ds.Put(dsKeyMetaIndex, buf); err != nil {
 		return err
 	}
-	return nil
-}
-
-// loadFromDS loads persisted indexes to memory datastructures. No locks needed
-// since its only called from New().
-func (mi *MinerIndex) loadFromDS() error {
-	buf, err := mi.ds.Get(dsKeyMetaIndex)
-	if err != nil {
-		if err == datastore.ErrNotFound {
-			mi.index = Index{
-				Meta:  MetaIndex{Info: make(map[string]Meta)},
-				Chain: ChainIndex{Power: make(map[string]Power)},
-			}
-			return nil
-		}
-		return err
-	}
-	var metaIndex MetaIndex
-	if err := cbor.DecodeInto(buf, &metaIndex); err != nil {
-		return err
-	}
-
-	var chainIndex ChainIndex
-	if _, err := mi.store.GetLastCheckpoint(&chainIndex); err != nil {
-		return err
-	}
-
-	mi.index.Meta = metaIndex
-	mi.index.Chain = chainIndex
-
 	return nil
 }

--- a/index/miner/miner.go
+++ b/index/miner/miner.go
@@ -101,7 +101,9 @@ func (mi *MinerIndex) Get() Index {
 	defer mi.lock.Unlock()
 	ii := Index{
 		Meta: MetaIndex{
-			Info: make(map[string]Meta, len(mi.index.Meta.Info)),
+			Online:  mi.index.Meta.Online,
+			Offline: mi.index.Meta.Offline,
+			Info:    make(map[string]Meta, len(mi.index.Meta.Info)),
 		},
 		Chain: ChainIndex{
 			LastUpdated: mi.index.Chain.LastUpdated,

--- a/index/slashing/slashing.go
+++ b/index/slashing/slashing.go
@@ -14,6 +14,7 @@ import (
 	"github.com/textileio/filecoin/lotus/types"
 	"github.com/textileio/filecoin/signaler"
 	txndstr "github.com/textileio/filecoin/txndstransform"
+	"github.com/textileio/filecoin/util"
 	"go.opencensus.io/stats"
 )
 
@@ -22,18 +23,23 @@ const (
 )
 
 var (
+	// hOffset is the # of tipsets from the heaviest chain to
+	// consider for index updating; this to reduce sensibility to
+	// chain reorgs
+	hOffset = uint64(5)
+
 	log = logging.Logger("index-slashing")
 )
 
 // API provides an abstraction to a Filecoin full-node
 type API interface {
-	ChainNotify(context.Context) (<-chan []*types.HeadChange, error)
 	ChainHead(context.Context) (*types.TipSet, error)
 	ChainGetTipSet(context.Context, types.TipSetKey) (*types.TipSet, error)
 	StateChangedActors(context.Context, cid.Cid, cid.Cid) (map[string]types.Actor, error)
 	StateReadState(ctx context.Context, act *types.Actor, ts *types.TipSet) (*types.ActorState, error)
 	ChainGetPath(context.Context, types.TipSetKey, types.TipSetKey) ([]*types.HeadChange, error)
 	ChainGetGenesis(context.Context) (*types.TipSet, error)
+	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
 }
 
 // SlashingIndex builds and provides slashing history of miners
@@ -123,42 +129,45 @@ func (s *SlashingIndex) Close() error {
 // start is a long running job that keeps the index up to date with chain updates
 func (s *SlashingIndex) start() {
 	defer close(s.finished)
-	n, err := s.api.ChainNotify(s.ctx)
-	if err != nil {
-		log.Fatalf("error when getting notify channel from lotus: %s", err)
+	if err := s.updateIndex(); err != nil {
+		log.Errorf("error on first updating slashing history: %s", err)
 	}
 	for {
 		select {
 		case <-s.ctx.Done():
 			log.Info("graceful shutdown of background slashing updater")
 			return
-		case hcs, ok := <-n:
-			if !ok {
-				log.Error("lotus notify channel closed")
-				return
-			}
-			log.Info("updating slashing index...")
-			currHeadTsk := types.NewTipSetKey(hcs[len(hcs)-1].Val.Cids...)
-			if err := s.updateIndex(currHeadTsk); err != nil {
+		case <-time.After(util.AvgBlockTime):
+
+			if err := s.updateIndex(); err != nil {
 				log.Errorf("error when updating slashing history: %s", err)
 				continue
 			}
-			log.Info("slashing index updated")
 		}
 	}
 }
 
 // updateIndex updates current index with a new discovered chain head.
-func (s *SlashingIndex) updateIndex(new types.TipSetKey) error {
+func (s *SlashingIndex) updateIndex() error {
+	log.Info("updating slashing index...")
+	heaviest, err := s.api.ChainHead(s.ctx)
+	if err != nil {
+		return err
+	}
+	new, err := s.api.ChainGetTipSetByHeight(s.ctx, heaviest.Height-hOffset, heaviest)
+	if err != nil {
+		return err
+	}
+	newtsk := types.NewTipSetKey(new.Cids...)
 	var index Index
-	ts, err := s.store.LoadAndPrune(s.ctx, new, &index)
+	ts, err := s.store.LoadAndPrune(s.ctx, newtsk, &index)
 	if err != nil {
 		return err
 	}
 	if index.Miners == nil {
 		index.Miners = make(map[string]Slashes)
 	}
-	_, path, err := chainsync.ResolveBase(s.ctx, s.api, ts, new)
+	_, path, err := chainsync.ResolveBase(s.ctx, s.api, ts, newtsk)
 	if err != nil {
 		return err
 	}
@@ -178,9 +187,8 @@ func (s *SlashingIndex) updateIndex(new types.TipSetKey) error {
 		stats.Record(mctx, mRefreshProgress.M(float64(i)/float64(len(path))))
 	}
 
-	headts := path[len(path)-1]
 	stats.Record(mctx, mRefreshDuration.M(int64(time.Since(start).Milliseconds())))
-	stats.Record(mctx, mUpdatedHeight.M(int64(headts.Height)))
+	stats.Record(mctx, mUpdatedHeight.M(int64(new.Height)))
 	stats.Record(mctx, mRefreshProgress.M(1))
 
 	s.lock.Lock()
@@ -188,6 +196,8 @@ func (s *SlashingIndex) updateIndex(new types.TipSetKey) error {
 	s.lock.Unlock()
 
 	s.signaler.Signal()
+	log.Info("slashing index updated")
+
 	return nil
 }
 
@@ -200,15 +210,12 @@ func updateFromPath(ctx context.Context, api API, index *Index, path []*types.Ti
 			return err
 		}
 		for addr := range patch {
-			info, ok := index.Miners[addr]
-			if !ok {
-				info = Slashes{}
-				index.Miners[addr] = info
-			}
+			info := index.Miners[addr]
 			if len(info.Epochs) > 0 && info.Epochs[len(info.Epochs)-1] == patch[addr] {
 				continue
 			}
 			info.Epochs = append(info.Epochs, patch[addr])
+			index.Miners[addr] = info
 		}
 	}
 	index.TipSetKey = types.NewTipSetKey(path[len(path)-1].Cids...).String()

--- a/lotus/client_test.go
+++ b/lotus/client_test.go
@@ -73,11 +73,13 @@ func TestClientChainNotify(t *testing.T) {
 		t.Fatalf("current head has invalid values")
 	}
 
-	select {
-	case <-time.After(time.Second * 50):
-		t.Fatalf("a new block should be received in less than ~45s")
-	case <-ch:
-		return
+	for {
+		select {
+		case <-time.After(time.Second * 50):
+			t.Fatalf("a new block should be received in less than ~45s")
+		case _, ok := <-ch:
+			fmt.Println(ok)
+		}
 	}
 }
 
@@ -125,6 +127,10 @@ func TestChainHead(t *testing.T) {
 	defer cls()
 
 	ts, err := c.ChainHead(context.Background())
+	if err != nil {
+		fmt.Println("LOL")
+	}
+	ts, err = c.ChainHead(context.Background())
 	checkErr(t, err)
 	if len(ts.Cids) == 0 || len(ts.Blocks) == 0 || ts.Height == 0 {
 		t.Fatalf("invalid tipset")

--- a/lotus/client_test.go
+++ b/lotus/client_test.go
@@ -73,13 +73,11 @@ func TestClientChainNotify(t *testing.T) {
 		t.Fatalf("current head has invalid values")
 	}
 
-	for {
-		select {
-		case <-time.After(time.Second * 50):
-			t.Fatalf("a new block should be received in less than ~45s")
-		case _, ok := <-ch:
-			fmt.Println(ok)
-		}
+	select {
+	case <-time.After(time.Second * 50):
+		t.Fatalf("a new block should be received in less than ~45s")
+	case <-ch:
+		return
 	}
 }
 
@@ -127,10 +125,6 @@ func TestChainHead(t *testing.T) {
 	defer cls()
 
 	ts, err := c.ChainHead(context.Background())
-	if err != nil {
-		fmt.Println("LOL")
-	}
-	ts, err = c.ChainHead(context.Background())
 	checkErr(t, err)
 	if len(ts.Cids) == 0 || len(ts.Blocks) == 0 || ts.Height == 0 {
 		t.Fatalf("invalid tipset")

--- a/lotus/jsonrpc/handler.go
+++ b/lotus/jsonrpc/handler.go
@@ -61,7 +61,7 @@ type response struct {
 // Handle
 
 type rpcErrFunc func(w func(func(io.Writer)), req *request, code int, err error)
-type chanOut func(reflect.Value) interface{}
+type chanOut func(reflect.Value, int64) error
 
 func doCall(methodName string, f reflect.Value, params []reflect.Value) (out []reflect.Value, err error) {
 	defer func() {
@@ -170,16 +170,25 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 	if handler.valOut != -1 {
 		resp.Result = callResult[handler.valOut].Interface()
 	}
+	if resp.Result != nil && reflect.TypeOf(resp.Result).Kind() == reflect.Chan {
+		// Channel responses are sent from channel control goroutine.
+		// Sending responses here could cause deadlocks on writeLk, or allow
+		// sending channel messages before this rpc call returns
 
-	w(func(w io.Writer) {
-		if resp.Result != nil && reflect.TypeOf(resp.Result).Kind() == reflect.Chan {
-			// this must happen in the writer callback, otherwise we may start sending
-			// channel messages before we send this response
-
-			//noinspection GoNilness // already checked above
-			resp.Result = chOut(callResult[handler.valOut])
+		//noinspection GoNilness // already checked above
+		err = chOut(callResult[handler.valOut], *req.ID)
+		if err == nil {
+			return // channel goroutine handles responding
 		}
 
+		log.Warnf("failed to setup channel in RPC call to '%s': %+v", req.Method, err)
+		resp.Error = &respError{
+			Code:    1,
+			Message: err.(error).Error(),
+		}
+	}
+
+	w(func(w io.Writer) {
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			log.Error(err)
 			return

--- a/lotus/jsonrpc/options.go
+++ b/lotus/jsonrpc/options.go
@@ -1,0 +1,33 @@
+package jsonrpc
+
+import "time"
+
+type ReconnectConfig struct {
+	Reconnect    bool
+	WaitInterval time.Duration
+	MaxRetries   int
+}
+
+type Config struct {
+	Reconnect ReconnectConfig
+}
+
+var defaultConfig = Config{
+	Reconnect: ReconnectConfig{
+		Reconnect:    false,
+		WaitInterval: time.Second * 5,
+		MaxRetries:   5,
+	},
+}
+
+type Option func(c *Config)
+
+// WithReconnect configures automatic connection setup if lost.
+// If maxRetries is zero, will retry forever.
+func WithReconnect(enabled bool, wi time.Duration, maxRetries int) func(*Config) {
+	return func(c *Config) {
+		c.Reconnect.Reconnect = enabled
+		c.Reconnect.WaitInterval = wi
+		c.Reconnect.MaxRetries = maxRetries
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,8 +2,13 @@ package util
 
 import (
 	"fmt"
+	"time"
 
 	ma "github.com/multiformats/go-multiaddr"
+)
+
+const (
+	AvgBlockTime = time.Second * 30
 )
 
 // TCPAddrFromMultiAddr converts a multiaddress to a string representation of a tcp address


### PR DESCRIPTION
While running our reputation index, which is a long-running thing, the lotus client was kind of fatal when the websocket connection was lost. This was a known thing for a while in the `jsonrpc` from lotus, so I jumped to help us both in that (https://github.com/filecoin-project/lotus/pull/1155).
The current solution that is in this PR, is more in line with a previous PR than the mentioned before... so it may change again with my new solution, but the current one is enough for our interests.

While installing and leaving running the service in the cloud instance, I discovered a set of issues or needed improvements to keep it more: reliable on lotus or self crashes, tested the persistence of indexed data and recovery after restarting, and some extra tunes to dockerized things that run on the cloud (and I also use locally to test things, since helps fast iteration with the many wires to connect).

I'll make some comments, but that's pretty much the summary of this.

Closes #41 
Closes #67